### PR TITLE
Update all emails to be @cascadiafest.org

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -4,7 +4,7 @@
 
 If you have any questions, comments, concerns, or to report anything that makes you feel uncomfortable or unsafe, you can use these channels:
 
-* Email: [info@cascadiajs.com](mailto:info@cascadiajs.com)
+* Email: [info@cascadiafest.org](mailto:info@cascadiafest.org)
 * In person: Any organizer, identified by STAFF badges or shirts for each day of CascadiaFest.
 * Immediate Response SMS number: [1 \(206\) 429-8441](tel:+12064298441)
 
@@ -32,7 +32,7 @@ Any participant asked to stop any harassing behavior is expected to comply immed
 
 If you feel uncomfortable, are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference Staff are identified by STAFF badges or shirts for each day of CascadiaFest.
 
-You can also send an email to [info@cascadiajs.com](mailto:info@cascadiajs.com).
+You can also send an email to [info@cascadiafest.org](mailto:info@cascadiafest.org).
 
 Immediate Response SMS number: [1 \(206\) 429-8441](tel:+12064298441)
 

--- a/website/public/_partials/footer.ejs
+++ b/website/public/_partials/footer.ejs
@@ -12,7 +12,7 @@
           <div class="row">
 
             <div class="col-xs-12">
-              <h5>Send <i class="fa fa-heart"></i> emails to: <a href="mailto:info@cascadiajs.com">info@cascadiajs.com</a></h5>
+              <h5>Send <i class="fa fa-heart"></i> emails to: <a href="mailto:info@cascadiafest.org">info@cascadiafest.org</a></h5>
             </div>
             <div class="col-xs-12">
               <p><%- site.description -%> <br>

--- a/website/public/staff/_data.json
+++ b/website/public/staff/_data.json
@@ -89,5 +89,10 @@
     }
   },
   "volunteers": {},
-  "contributors": {}
+  "contributors": {
+    "jembijoux": {
+      "username": "jembijoux",
+      "avatar": "https://avatars2.githubusercontent.com/u/8083892?v=3&s=460"
+    }
+  }
 }


### PR DESCRIPTION
Saw a mention in #volunteering (via slack) that this was a quick thing someone could help with. If that's helpful, here you go @davethegr8 
- Change all emails from @cascadiajs.com to @cascadiafest.org
