### PR TITLE
Antialiasing for Light Text

### DIFF
--- a/website/public/assets/css/_colors.sass
+++ b/website/public/assets/css/_colors.sass
@@ -4,7 +4,7 @@ $tan-light: #f2f1df
 
 
 // Event Colors
-$primary-green: #137630
+$primary-green: #f37630
 $primary-green-dark: #19594d
 $primary-green-darker: #0c3b40
 $primary-green-light: #22735c

--- a/website/public/assets/css/_colors.sass
+++ b/website/public/assets/css/_colors.sass
@@ -4,7 +4,7 @@ $tan-light: #f2f1df
 
 
 // Event Colors
-$primary-green: #f37630
+$primary-green: #137630
 $primary-green-dark: #19594d
 $primary-green-darker: #0c3b40
 $primary-green-light: #22735c

--- a/website/public/assets/css/_general.sass
+++ b/website/public/assets/css/_general.sass
@@ -41,6 +41,8 @@ body
 #hero
   color: white
   background: linear-gradient(to bottom, $primary-blue-lighter, $primary-blue-light)
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: antialiased
 
   span.label-primary
     background-color: $primary-blue-dark
@@ -76,7 +78,8 @@ body
   background-position: bottom center
   background-repeat: repeat-x
   color: white
-
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: antialiased
 
 #connect
   background-color: $primary-green-light
@@ -92,17 +95,28 @@ body
       border-color: white
       border-width: 2px
       color: white
+      -webkit-font-smoothing: antialiased
+      -moz-osx-font-smoothing: antialiased
+
       ::-webkit-input-placeholder
-       color: $tan-light
+        color: $tan-light
+        -webkit-font-smoothing: antialiased
+        -moz-osx-font-smoothing: antialiased
 
       :-moz-placeholder
-       color: $tan-light
+        color: $tan-light
+        -webkit-font-smoothing: antialiased
+        -moz-osx-font-smoothing: antialiased
 
       ::-moz-placeholder
         color: $tan-light
+        -webkit-font-smoothing: antialiased
+        -moz-osx-font-smoothing: antialiased
 
       :-ms-input-placeholder
         color: $tan-light
+        -webkit-font-smoothing: antialiased
+        -moz-osx-font-smoothing: antialiased
 
 #latest-news
   padding-top: 2rem
@@ -116,6 +130,8 @@ body
 .theme
   color: white
   padding: 1em
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: antialiased
 
   &.css
     background-color: $primary-purple

--- a/website/public/assets/css/_typography.sass
+++ b/website/public/assets/css/_typography.sass
@@ -36,6 +36,8 @@ a
       &:hover
         color: white
         background-color: $primary-green-dark
+        -webkit-font-smoothing: antialiased
+        -moz-osx-font-smoothing: antialiased
     .nav-link.active,
     .nav-link.active:focus,
     .nav-link.active:hover,
@@ -45,6 +47,8 @@ a
       color: white
       cursor: default
       background-color: $primary-green!important
+      -webkit-font-smoothing: antialiased
+      -moz-osx-font-smoothing: antialiased
 
 #hero-message
   font-family: 'Lora', serif
@@ -59,11 +63,17 @@ a
     &:hover
       background-color: $primary-blue
       color: white
+      -webkit-font-smoothing: antialiased
+      -moz-osx-font-smoothing: antialiased
 
 #connect
   color: $tan-light
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: antialiased
   h3
     color: $primary-green-darker
+    -webkit-font-smoothing: subpixel-antialiased
+    -moz-osx-font-smoothing: unset
 
   // Button style overrides
   .btn-primary

--- a/website/public/assets/css/_venue.sass
+++ b/website/public/assets/css/_venue.sass
@@ -15,7 +15,10 @@
     padding: 1.5em
     background-color: $primary-green-light
     color: white
+    -webkit-font-smoothing: antialiased
+    -moz-osx-font-smoothing: antialiased
     font-size: 1rem
+
     @include media-breakpoint-up(lg)
       padding: 2em 2.5em
 


### PR DESCRIPTION
Improves legibility by adding the following CSS to all instances of light text on a darker background:

``` css
  -webkit-font-smoothing: antialiased
  -moz-osx-font-smoothing: antialiased
```

![original on the left, updated on the right](https://cloud.githubusercontent.com/assets/1395360/15262232/3fc33742-191e-11e6-8de0-029807ea3a75.jpg)
