### PR TITLE
Remove buddy lodging copy

### DIFF
--- a/website/public/_partials/venue.ejs
+++ b/website/public/_partials/venue.ejs
@@ -29,9 +29,6 @@
           <p class="darken">All accommodations are being arranged by the conference, please do not contact Semiahmoo directly.</p>
 
           <p class="pt1 pb1 text-sm-center"><a href="https://ti.to/event-loop/cascadiafest-2016/" class="btn btn-primary">Purchase Tickets and Lodging <i class="fa fa-ticket"></a></p>
-
-          <h5><strong>Special instructions for those wanting to buddy-up for lodging</strong></h5>
-          <p>For those who would like to share a double queen room or suite with a friend, please do not purchase a lodging ticket yet. You will fill out <a href="http://goo.gl/forms/TX0p35A8SD" class="blended-link">this form</a>. You must have the name of your rooming buddy at the time of entry. You will receive a follow-up form with a secret link to purchase a CascadiaFest 3-day ticket with double queen accommodation. We have priced out the double queen rooms for shared occupancy (per person). The suites are priced for the entire unit as we are trying to preserve them for families.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
We're not using the buddy lodging form now that anyone can register for a double room.

/cc @davethegr8 @crtr0 
