### PR TITLE
Basic tweaks for the sponsor logos

### DIFF
--- a/website/public/assets/css/_schedule.scss
+++ b/website/public/assets/css/_schedule.scss
@@ -76,6 +76,7 @@
     .max-height {
       max-width: 100%;
       height: 50px; }
+
     .max-width {
       width: 100%;
       max-width: 180px; }

--- a/website/public/css/_schedule.ejs
+++ b/website/public/css/_schedule.ejs
@@ -232,7 +232,7 @@
           <br>
           <br>
           <a href="<%- public.sponsors._data.ibmdesign.url %>" class="schedule-sponsor-logo break-wrap" >
-            <img src="<%- public.sponsors._data.ibmdesign.logo %>" class="max-width" />
+            <img src="<%- public.sponsors._data.ibmdesign.logo %>" alt="Sponsored by <%- public.sponsors._data.ibmdesign.name %>" class="max-width" height="70" />
           </a>
         </td>
       </tr>

--- a/website/public/css/_schedule.ejs
+++ b/website/public/css/_schedule.ejs
@@ -232,7 +232,7 @@
           <br>
           <br>
           <a href="<%- public.sponsors._data.ibmdesign.url %>" class="schedule-sponsor-logo break-wrap" >
-            <img src="<%- public.sponsors._data.ibmdesign.logo %>" alt="Sponsored by <%- public.sponsors._data.ibmdesign.name %>" class="max-width" height="70" />
+            <img src="<%- public.sponsors._data.ibmdesign.logo %>" alt="Sponsored by <%- public.sponsors._data.ibmdesign.name %>" width="180" />
           </a>
         </td>
       </tr>

--- a/website/public/node/_schedule.ejs
+++ b/website/public/node/_schedule.ejs
@@ -234,7 +234,7 @@
           <br>
           <br>
           <a href="<%- public.sponsors._data.twilio.url %>" class="schedule-sponsor-logo break-wrap">
-              <img src="<%- public.sponsors._data.twilio.logo %>" alt="Sponsored by <%- public.sponsors._data.twilio.name %>" class="max-height" />
+              <img src="<%- public.sponsors._data.twilio.logo %>" alt="Sponsored by <%- public.sponsors._data.twilio.name %>" class="max-width" height="70" />
             </a>
         </td>
       </tr>

--- a/website/public/node/_schedule.ejs
+++ b/website/public/node/_schedule.ejs
@@ -234,7 +234,7 @@
           <br>
           <br>
           <a href="<%- public.sponsors._data.twilio.url %>" class="schedule-sponsor-logo break-wrap">
-              <img src="<%- public.sponsors._data.twilio.logo %>" alt="Sponsored by <%- public.sponsors._data.twilio.name %>" class="max-width" height="70" />
+              <img src="<%- public.sponsors._data.twilio.logo %>" alt="Sponsored by <%- public.sponsors._data.twilio.name %>" width="180" />
             </a>
         </td>
       </tr>


### PR DESCRIPTION
Things should all look a little bit better. Adding the single dimension back in for these items seems to clear up some odd behavior at different smaller sizes.
